### PR TITLE
Bug Fixes and Minor Enhancements

### DIFF
--- a/mwana/apps/smgl/lookups.py
+++ b/mwana/apps/smgl/lookups.py
@@ -31,7 +31,7 @@ class DistrictLookup(ModelLookup):
 
 class FacilityLookup(ModelLookup):
     model = Location
-    exclude = {'type__singular__in': ['district', 'Province', 'Zone']}
+    exclude = {'type__singular__in': ['district', 'Province', 'Zone', 'Head Office']}
     search_fields = ('name__icontains', )
 
     def get_queryset(self):
@@ -49,7 +49,7 @@ class FacilityLookup(ModelLookup):
         if district:
             loc = Location.objects.get(pk=district)
             results = get_location_tree_nodes(loc)
-            results = [x for x in results if x.type.singular != 'Zone']
+            results = [x for x in results if x.type.singular not in ['Zone', 'Head Office']]
         return results
 
     def get_item_label(self, item):

--- a/mwana/apps/smgl/templates/smgl/mother_history.html
+++ b/mwana/apps/smgl/templates/smgl/mother_history.html
@@ -8,6 +8,7 @@
 <h2>Mother's Record History</h2>
 <h3>{{ mother }}</h3>
 <a href="?export=1"><button class="btn" name="export">Export</button></a>
+<a href="{% url mothers %}">Back to Mothers</a>
 {{ message_table.as_html }}
 </div>
 

--- a/mwana/apps/smgl/templates/smgl/sms_user_statistics.html
+++ b/mwana/apps/smgl/templates/smgl/sms_user_statistics.html
@@ -54,7 +54,7 @@
       <input type="submit" class="btn" name="filter" value="Filter" />
       <input type="submit" class="btn" name="export" value="Export" />
   </form>
-  <h2>User's SMS Statistics</h2>
+  <h2>{{ user.name }}'s SMS Statistics</h2>
   <p><a href="{% url 'sms-user-history' user.name %}">Back to User</a></p>
   <div id="records">
     {{ summary_report_table.as_html }}

--- a/mwana/apps/smgl/tests/test_reminders.py
+++ b/mwana/apps/smgl/tests/test_reminders.py
@@ -7,10 +7,8 @@ from mwana.apps.contactsplus.models import ContactType
 
 from mwana.apps.smgl.tests.shared import SMGLSetUp, create_mother
 from mwana.apps.smgl import const
-from mwana.apps.smgl.models import Location
 from mwana.apps.smgl.reminders import (send_inactive_notice,
     send_expected_deliveries)
-
 
 
 class SMGLReminderTest(SMGLSetUp):
@@ -45,7 +43,6 @@ class SMGLReminderTest(SMGLSetUp):
         self.assertEqual(out_msgs.count(), 2)
         self.assertEqual(out_msgs[1].text, const.INACTIVE_CONTACT)
 
-
     def testExpectedEddReminder(self):
         Message.objects.all().delete()
 
@@ -53,7 +50,7 @@ class SMGLReminderTest(SMGLSetUp):
         send_expected_deliveries(router_obj=self.router)
         msgs = Message.objects.all()
         self.assertEqual(msgs.count(), 1)
-        self.assertEqual(msgs[0].text, const.EXPECTED_EDDS % {'edd_count':1})
+        self.assertEqual(msgs[0].text, const.EXPECTED_EDDS % {'edd_count': 1})
 
     def testExpectedEddReminderBeforeRange(self):
         Message.objects.all().delete()

--- a/mwana/apps/smgl/utils.py
+++ b/mwana/apps/smgl/utils.py
@@ -190,6 +190,7 @@ def get_location_tree_nodes(location, locations=None):
     for child in location.location_set.all():
         locations.append(child)
         get_location_tree_nodes(child, locations)
+    locations = sorted(locations, key=lambda loc: loc.name)
     return locations
 
 

--- a/mwana/apps/smgl/views.py
+++ b/mwana/apps/smgl/views.py
@@ -923,9 +923,9 @@ def sms_users(request):
         contacts = contacts.filter(types__in=[c_type])
     contacts = contacts.filter(location__in=locations)
 
-    # filter by created_date
-    contacts = filter_by_dates(contacts, 'created_date',
-                             start=start_date, end=end_date)
+    # filter by latest_sms_date, which is a property on the model, not a field
+    contacts = [x for x in contacts if x.latest_sms_date != None and x.latest_sms_date.date() >= start_date and x.latest_sms_date.date() <= end_date]
+    contacts = sorted(contacts, key=lambda contact: contact.latest_sms_date, reverse=True)
 
     # render as CSV if export
     if request.GET.get('export'):

--- a/mwana/apps/smgl/views.py
+++ b/mwana/apps/smgl/views.py
@@ -36,8 +36,8 @@ from .utils import (export_as_csv, filter_by_dates, get_current_district,
 
 def mothers(request):
     province = district = facility = zone = None
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
     edd_start_date = edd_end_date = None
 
     mothers = PregnantMother.objects.all()
@@ -167,8 +167,8 @@ def mother_history(request, id):
 def statistics(request, id=None):
     records = []
     facility_parent = None
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
     province = district = facility = None
 
@@ -372,8 +372,8 @@ def statistics(request, id=None):
 def reminder_stats(request):
     records = []
     province = district = facility = None
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
     record_types = ['edd', 'nvd', 'pos', 'ref']
     field_mapper = {'edd': 'Expected Delivery Date', 'nvd': 'Next Visit Date',
@@ -469,8 +469,8 @@ def reminder_stats(request):
 def report(request):
     records = []
     province = district = locations = None
-    start_date = date(date.today().year, 1, 1)
-    end_date = date(date.today().year, 12, 31)
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
     if request.GET:
         form = StatisticsFilterForm(request.GET)
@@ -598,8 +598,8 @@ def report(request):
     positive_syph = percentage(positive_syphs.count(),
                           syph_tests.count())
     positive_mothers = positive_syphs.values_list('mother', flat=True)
-    mothers = PregnantMother.objects.filter(id__in=positive_mothers)
-    treatments = mothers.annotate(Count('syphilistreatment')) \
+    positive_mothers = PregnantMother.objects.filter(id__in=positive_mothers)
+    treatments = positive_mothers.annotate(Count('syphilistreatment')) \
                         .values_list('syphilistreatment__count', flat=True)
     positive_syph_completed = sum(i >= 3 for i in treatments)
 
@@ -612,6 +612,8 @@ def report(request):
           'value': cbas},
          {'data': "Number of Data Clerks Registered",
           'value': clerks},
+         {'data': "Number of Pregnent Mothers Registered",
+          'value': mothers.count()},
          {'data': 'Percentage of Women who attended at least 4 ANC visits',
           'value': p_gtefour_ancs},
          {'data': "Percentage of women who returned for ANCs after being reminded",
@@ -672,8 +674,8 @@ def notifications(request):
     """
     Report on notifications to help_admin users
     """
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
  #   province = district = facility = None
 
@@ -734,8 +736,8 @@ def notifications(request):
 
 
 def referrals(request):
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
     province = district = facility = None
 
@@ -809,8 +811,8 @@ def sms_records(request):
     Report on all messages
     """
     province = district = facility = keyword = None
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
     sms_records = Message.objects.filter(direction="I")
 
@@ -888,8 +890,8 @@ def sms_users(request):
     """
     Report on all users
     """
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
     province = district = c_type = None
 
@@ -1103,8 +1105,8 @@ def sms_user_statistics(request, name):
 
 def help(request):
     province = district = facility = None
-    end_date = datetime.datetime.today()
-    start_date = (end_date - timedelta(days=14)).date()
+    end_date = datetime.datetime.today().date()
+    start_date = end_date - timedelta(days=14)
 
     help_reqs = HelpRequest.objects.all()
 


### PR DESCRIPTION
Resolves:

National Stats Page
- SMGL and DMO office are not facilities and thus should be removed from the list i.e. from the drop down menu when a user selects a facility and from the list that appears when a user clicks on the Kalomo District hyper link.
- when a user filters and selects e.g. page 2 on the filter End date it displays *Enter a valid date which stays on the page when next page or previous page is selected.

Reports Page
- when you open the page you only see Zeros and no figures can we display data for the past 14 days instead, then if a users need more data they can filter further.
- also add in total number of registered pregnant women just after the registered data clerks.
- also could we add in figures for No of Clinical workers, Data Clerks and CBAs registered as this is information is currently blank unless one filters.

SMS Users Page
- can the page display by default active users e.g within the 14 day range as opposed to having no data.
- on the users page when on selects the user's sms statistics can we add the users name of the page to make it easier to view the data

Mothers Page
- have you had a chance to work on the back button or link as it is a challenge to go back to the previous page unless one clicks on the mothers page again
- need to remove SMGL and DMO office from the facility list as these are not facilities.
